### PR TITLE
mysql_xty may generate invalid mysql_type_codes.h

### DIFF
--- a/src/apq-2.1/mysql_xty
+++ b/src/apq-2.1/mysql_xty
@@ -4,7 +4,7 @@ PATH=".:$PATH"
 
 HDRFILE=$(mysql_incl)/mysql_com.h
 
-sed <$HDRFILE -n '/enum_field_types/,/};/p' | sed 's|enum||;s|enum_field_types||;s|[{};]||g;s|,|\
+cpp -P $HDRFILE | sed -n '/enum_field_types/,/};/p' | sed 's|enum||;s|enum_field_types||;s|[{};]||g;s|,|\
 |g;s|[ 	]*||g' | sed '/^$/d;s|=[0-9]*||g' \
         | while read NAME ; do
                 echo "  { \"$NAME\", $NAME },"


### PR DESCRIPTION
Use cpp in mysql_xty to get rid of comments between enumeration items definition, 
for mariadb 10.0.26, the comments causing invalid mysql_type_codes.h being generated.