### PR TITLE
Drop SDL directory from source code.

### DIFF
--- a/configure
+++ b/configure
@@ -819,7 +819,7 @@ if [ -z "$TMP" ] ; then
    if [ -n "$PKGCONFIG" ] ; then
       echo -n "configuring SDL (pkg-config)... "
       # bundled SDL here
-      SDLLIBS=`(exec $PKGCONFIG --libs sdl 2>/dev/null)`
+      SDLLIBS=`(exec $PKGCONFIG --libs sdl 2>/dev/null)`" -lSDL_image"
       SDLINCL=`(exec $PKGCONFIG --cflags sdl 2>/dev/null)`
       if [ $? -ne 0 ] ; then
          SDLLIBS=""
@@ -837,10 +837,10 @@ if [ -z "$TMP" ] ; then
          SDLINCL="-I/usr/local/include/SDL11"
       elif [ "$OS" = "darwin" ] ; then
          SDLLIBS="/Library/Frameworks/SDL.framework/SDL /Library/Frameworks/SDL_image.framework/SDL_image"
-         SDLINCL="-I/Library/Frameworks/SDL.framework/include"
+         SDLINCL="-I/Library/Frameworks/SDL.framework/Headers -I/Library/Frameworks/SDL_image.framework/Headers"
       else
-         SDLLIBS="-l SDL -l SDL_image"
-         SDLINCL="-I/usr/include/SDL"
+         SDLLIBS="-L/usr/local/lib -lSDL -lSDL_image"
+         SDLINCL="-I/usr/local/include/SDL"
       fi
    fi
 else
@@ -888,9 +888,9 @@ if test -r spar_os-sdl.ads ; then
 else
    cd ../test
    if [ "$OS" = "darwin" ] ; then
-      (exec "$CC" sdlversion.c "$SDLINCL" "$SDLLIBS" > /dev/null 2>/dev/null )
+      (exec "$CC" sdlversion.c $SDLINCL $SDLLIBS > /dev/null 2>/dev/null )
    else
-      (exec "$CC" sdlversion.c -I/usr/local/include -L/usr/local/lib -lSDL)
+      (exec "$CC" sdlversion.c -I/usr/local/include/SDL -L/usr/local/lib -lSDL)
    fi
    if [ -f "./a.exe" ] ; then # Cygwin makes Windows executables
       TMP=`./a.exe`

--- a/src/GNUmakefile.orig
+++ b/src/GNUmakefile.orig
@@ -192,7 +192,7 @@ max: clean c_os.o c_scanner.o c_gstreamer.o
 	gnatlink spar.ali ${GSTREAMERLIBS} ${GSTREAMEROUT} c_os.o c_scanner.o $(LIBS)
 
 clean:
-	$(MAKE) -C areadline clean
+	-$(MAKE) -C areadline clean
 	$(MAKE) -C adacgi-1.6 clean
 	$(MAKE) -C apq-2.1 clean
 	$(MAKE) -C bdb clean
@@ -202,7 +202,7 @@ clean:
 	-rm -f *.gcda *.gcno *.gcov coverage.info gmon.out testsuite/templates/gmon.out testsuite/goodsuite/gmon.out testsuite/helpsuite/gmon.out testsuite/third_party/gmon.out testsuite/gmon.out testsuite/testsuite010_pragmas/gmon.out testsuite/testsuite015_arrays/gmon.out testsuite/testsuite012_calendar/gmon.out
 
 distclean:
-	$(MAKE) -C areadline clean
+	-$(MAKE) -C areadline clean
 	$(MAKE) -C adacgi-1.6 clean
 	#$(MAKE) -C ADAVOX-0.51 clobber
 	$(MAKE) -C apq-2.1 clobber

--- a/src/apq-2.1/Makefile
+++ b/src/apq-2.1/Makefile
@@ -4,7 +4,7 @@
 # Licensed under the ACL (Ada Community License)
 # or GPL2 :
 
-include Makeincl
+#include Makeincl
 
 DISTDIR=apq-$(VERSION)
 DISTFILE=apq-$(VERSION).tar.gz
@@ -25,7 +25,7 @@ all:	setup$(HAVE_MY) mysql$(HAVE_MY) postgresql$(HAVE_PG) libapq.a finish
 
 tmysql::
 	rm -f tmysql mysql.trc
-	gnatmake -gnatf tmysql -largs -lapq $(MY_LIBS) 
+	gnatmake -gnatf tmysql -largs -lapq $(MY_LIBS)
 
 
 setup0: # MySQL support is not being included
@@ -85,7 +85,7 @@ install: libapq.a
 	@echo "  2. make"
 	@echo "  3. follow instructions given."
 	@echo "--"
-	
+
 uninstall:
 	HAVE_PG=1 HAVE_MY=1 ./install_lib uninstall
 

--- a/src/c_os.c
+++ b/src/c_os.c
@@ -366,11 +366,11 @@ int C_install_sigpipe_handler( int *flag_address ) {
 // SDL TESTING
 
 #ifdef FREEBSD
-#include <SDL/SDL.h>
-#include <SDL/SDL_video.h>
+#include <SDL.h>
+#include <SDL_video.h>
 #else
-#include <SDL/SDL.h>
-#include <SDL/SDL_video.h>
+#include <SDL.h>
+#include <SDL_video.h>
 #endif
 
 

--- a/test/sdlversion.c
+++ b/test/sdlversion.c
@@ -1,5 +1,5 @@
-#include <SDL/SDL.h>
-#include <SDL/SDL_video.h>
+#include <SDL.h>
+#include <SDL_video.h>
 
 #include <stdio.h>
 


### PR DESCRIPTION
Drop SDL directory from source code as it is included in sdl-config or pkg-config paths:
$ pkg-config --cflags sdl
-D_GNU_SOURCE=1 -D_THREAD_SAFE -I/usr/local/include/SDL
$ sdl-config  --cflags
-I/usr/local/include/SDL -D_GNU_SOURCE=1 -D_THREAD_SAFE
(see mail exchange from the 30th of October'2017, Pascal)
