### PR TITLE
Emulate group_member on macOS.

### DIFF
--- a/src/c_os.c
+++ b/src/c_os.c
@@ -27,8 +27,10 @@ int group_member(gid_t gid) {
   }
   ret = 0;
   for (i = 0; i < ngroups; i++) {
-    if (gid == groups[i])
-      ret = i;
+    if (gid == groups[i]) {
+      ret = 1;
+      break;
+      }
   }
   return ret;
 }

--- a/src/c_os.c
+++ b/src/c_os.c
@@ -14,6 +14,25 @@
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
+#include <limits.h>
+
+#ifdef __APPLE__
+int group_member(gid_t gid) {
+  int ngroups, i, ret;
+  int groups[NGROUPS_MAX];
+
+  ngroups = NGROUPS_MAX;
+  if (getgrouplist(getlogin(), -1, groups, &ngroups) == -1) {
+    printf ("Groups array is too small: %d\n", ngroups);
+  }
+  ret = 0;
+  for (i = 0; i < ngroups; i++) {
+    if (gid == groups[i])
+      ret = i;
+  }
+  return ret;
+}
+#endif
 
 /* C ERRNO                                                  */
 /*                                                          */


### PR DESCRIPTION
Unfortunately, group_member is not part of unistd.h on Darwin / macOS.
Thus I add an emulation.